### PR TITLE
Upgrade TRE - merge test. Attempt 2.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
       "DOCKER_GROUP_ID": "${localEnv:DOCKER_GROUP_ID}",
       "INTERACTIVE": "true",
       "OSS_REPO": "OxBRCInformatics/AzureTRE",
-      "OSS_VERSION": "v0.15.1"
+      "OSS_VERSION": "v0.15.2"
     }
   },
   "runArgs": [

--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -4,5 +4,5 @@ Workspace Templates are located in this folder. These Templates are for the Comp
 
 | Template name | Description |
 | --- | --- |
-| tre-service-guacamole-linuxvm-ouh2 | This is a custom Linux image for OUH |
-| tre-service-guacamole-windowsvm-ouh2 | This is a custom Windows image for OUH |
+| tre-service-guacamole-linuxvm-ouh2 | This is a custom Linux image for OUH use |
+| tre-service-guacamole-windowsvm-ouh2 | This is a custom Windows image for OUH use |

--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -4,6 +4,6 @@ Workspace Templates are located in this folder. These Templates are for the Comp
 
 | Template name | Description |
 | --- | --- |
-| tre-service-guacamole-linuxvm-ouh2 | This is a custom Linux image for OUH use |
-| tre-service-guacamole-windowsvm-ouh2 | This is a custom Windows image for OUH use |
+| tre-service-guacamole-linuxvm-ouh2    | This is a custom Linux image for OUH use   |
+| tre-service-guacamole-windowsvm-ouh2  | This is a custom Windows image for OUH use |
 


### PR DESCRIPTION
Previous branch resulted in errors with deployment due to a loss of internet, followed by terraform errors in following runs.

To avoid this, the best next step is to use a new TRE_ID. To do this when deploying from a feature branch, we must create a new branch, to create a new refid.

The same updates will be tested.

BUG FIXES:

- Remove .sh extension from nexus renewal script so CRON job executes (https://github.com/microsoft/AzureTRE/issues/3742)
- Upgrade porter version to v1.0.15 and on error getting porter outputs return dict (https://github.com/microsoft/AzureTRE/issues/3744)
- Fix notifications displaying workspace name rather than actual resource (https://github.com/microsoft/AzureTRE/issues/3746)
- Fix SecuredByRole fails if app roles are not loaded (https://github.com/microsoft/AzureTRE/issues/3752)
- Fix workspace not loading fails if operation or history roles are not loaded (https://github.com/microsoft/AzureTRE/issues/3755)
