### PR TITLE
Upgrade TRE to v16.0

### DIFF
--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -2,8 +2,7 @@
 
 Workspace Templates are located in this folder. These Templates are for the Composition Service to make instances of.
 
-| Template name | Description |
-| --- | --- |
-| tre-service-guacamole-linuxvm-ouh2    | This is a custom Linux image for OUH use   |
-| tre-service-guacamole-windowsvm-ouh2  | This is a custom Windows image for OUH use |
-
+| VM type | Template name | Description |
+| --- | --- | --- |
+| Linux | tre-service-guacamole-linuxvm-ouh2    | This is a custom Linux image for OUH use   |
+| Windows | tre-service-guacamole-windowsvm-ouh2  | This is a custom Windows image for OUH use |


### PR DESCRIPTION
Upgrade TRE from v15.2 to v16.0


**BREAKING CHANGES & MIGRATIONS**: To resolve the Airlock import issue described in (#3767), the new airlock import review template will need to be registered using make workspace_bundle BUNDLE=airlock-import-review. Any existing airlock import review workspaces will need to be upgraded.

Once you have upgraded the import review workspaces, delete the private endpoint, named pe-stg-import-inprogress-blob-* in the core resource group, and then run make deploy-core to reinstate the private endpoint and DNS records.

**ENHANCEMENTS**:

Security updates aligning to Dependabot, MS Defender for Cloud and Synk (#3796)
**BUG FIXES**:

- Fix issue where updates fail as read only is not configured consistently on schema fields (#3691)
- When getting available address spaces allow those allocated to deleted workspaces to be reassigned (#3691)
- Update Python packages, and fix breaking changes (#3764)
- Enabling support for more than 20 users/groups in Workspace API (#3759)
- Airlock Import Review workspace uses dedicated DNS zone to prevent conflict with core (#3767)
