### PR TITLE
Upgrade TRE to v16.0 merge test

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -108,6 +108,7 @@ ARG OSS_VERSION
 ARG OSS_REPO
 ENV AZURETRE_HOME=/home/$USERNAME/AzureTRE
 COPY .devcontainer/scripts/install-azure-tre-oss.sh .devcontainer/devcontainer.json /tmp/
+# hadolint ignore=DL3004
 RUN oss_version_in_json=$(grep -oP '(?<="OSS_VERSION": ")[^"]*' /tmp/devcontainer.json) \
     && /tmp/install-azure-tre-oss.sh "${OSS_REPO:-microsoft/AzureTRE}" "${OSS_VERSION:-$oss_version_in_json}" "${AZURETRE_HOME}" \
     && sudo chown -R $USERNAME ${AZURETRE_HOME}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -98,8 +98,9 @@ ARG OSS_VERSION
 ENV AZURETRE_HOME=/home/$USERNAME/AzureTRE
 COPY .devcontainer/scripts/install-azure-tre-oss.sh .devcontainer/devcontainer.json /tmp/
 # hadolint ignore=DL3004
-RUN oss_version_in_json=$(grep -oP '(?<="OSS_VERSION": ")[^"]*' /tmp/devcontainer.json) \
-    && /tmp/install-azure-tre-oss.sh "${OSS_VERSION:-$oss_version_in_json}" "${AZURETRE_HOME}" \
+RUN oss_repo_in_json=$(grep -oP '(?<="OSS_REPO": ")[^"]*' /tmp/devcontainer.json) \
+    && oss_version_in_json=$(grep -oP '(?<="OSS_VERSION": ")[^"]*' /tmp/devcontainer.json) \
+    && /tmp/install-azure-tre-oss.sh "${OSS_REPO:-$oss_repo_in_json}" "${OSS_VERSION:-$oss_version_in_json}" "${AZURETRE_HOME}"  \
     && sudo chown -R $USERNAME ${AZURETRE_HOME}
 
 # Install tre-cli

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -93,14 +93,23 @@ RUN echo "export HISTFILE=$HOME/commandhistory/.bash_history" >> "$HOME/.bashrc"
 COPY ./.devcontainer/scripts/gh.sh /tmp/
 RUN if [ "${INTERACTIVE}" = "true" ]; then /tmp/gh.sh; fi
 
+# # Install AzureTRE OSS
+# ARG OSS_VERSION
+# ENV AZURETRE_HOME=/home/$USERNAME/AzureTRE
+# COPY .devcontainer/scripts/install-azure-tre-oss.sh .devcontainer/devcontainer.json /tmp/
+# # hadolint ignore=DL3004
+# RUN oss_repo_in_json=$(grep -oP '(?<="OSS_REPO": ")[^"]*' /tmp/devcontainer.json) \
+#     && oss_version_in_json=$(grep -oP '(?<="OSS_VERSION": ")[^"]*' /tmp/devcontainer.json) \
+#     && /tmp/install-azure-tre-oss.sh "${OSS_REPO:-$oss_repo_in_json}" "${OSS_VERSION:-$oss_version_in_json}" "${AZURETRE_HOME}"  \
+#     && sudo chown -R $USERNAME ${AZURETRE_HOME}
+
 # Install AzureTRE OSS
 ARG OSS_VERSION
+ARG OSS_REPO
 ENV AZURETRE_HOME=/home/$USERNAME/AzureTRE
 COPY .devcontainer/scripts/install-azure-tre-oss.sh .devcontainer/devcontainer.json /tmp/
-# hadolint ignore=DL3004
-RUN oss_repo_in_json=$(grep -oP '(?<="OSS_REPO": ")[^"]*' /tmp/devcontainer.json) \
-    && oss_version_in_json=$(grep -oP '(?<="OSS_VERSION": ")[^"]*' /tmp/devcontainer.json) \
-    && /tmp/install-azure-tre-oss.sh "${OSS_REPO:-$oss_repo_in_json}" "${OSS_VERSION:-$oss_version_in_json}" "${AZURETRE_HOME}"  \
+RUN oss_version_in_json=$(grep -oP '(?<="OSS_VERSION": ")[^"]*' /tmp/devcontainer.json) \
+    && /tmp/install-azure-tre-oss.sh "${OSS_REPO:-microsoft/AzureTRE}" "${OSS_VERSION:-$oss_version_in_json}" "${AZURETRE_HOME}" \
     && sudo chown -R $USERNAME ${AZURETRE_HOME}
 
 # Install tre-cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
       "DOCKER_GROUP_ID": "${localEnv:DOCKER_GROUP_ID}",
       "INTERACTIVE": "true",
       "OSS_REPO": "OxBRCInformatics/AzureTRE",
-      "OSS_VERSION": "v0.15.2"
+      "OSS_VERSION": "v0.16.0"
     }
   },
   "runArgs": [

--- a/.devcontainer/scripts/install-azure-tre-oss.sh
+++ b/.devcontainer/scripts/install-azure-tre-oss.sh
@@ -5,14 +5,16 @@ set -o nounset
 # Uncomment this line to see each command for debugging (careful: this will show secrets!)
 # set -o xtrace
 
-oss_version="$1"
-oss_home="$2"
+oss_repo="$1"
+oss_version="$2"
+oss_home="$3"
 archive=/tmp/AzureTRE.tar.gz
 
-wget -O "$archive" "http://github.com/microsoft/AzureTRE/archive/${oss_version}.tar.gz" --progress=dot:giga
+wget -O "$archive" "http://github.com/${oss_repo}/archive/${oss_version}.tar.gz" --progress=dot:giga
 
 mkdir -p "$oss_home"
 tar -xzf "$archive" -C "$oss_home" --strip-components=1
 rm "$archive"
 
+echo "${oss_repo}" > "$oss_home/repository.txt"
 echo "${oss_version}" > "$oss_home/version.txt"

--- a/.devcontainer/scripts/install-azure-tre-oss.sh
+++ b/.devcontainer/scripts/install-azure-tre-oss.sh
@@ -16,5 +16,5 @@ mkdir -p "$oss_home"
 tar -xzf "$archive" -C "$oss_home" --strip-components=1
 rm "$archive"
 
-echo "${oss_repo}" > "$oss_home/repository.txt"
+# echo "${oss_repo}" > "$oss_home/repository.txt"
 echo "${oss_version}" > "$oss_home/version.txt"

--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -9,13 +9,13 @@ Workspace Templates are located in this folder. These Templates are for the Comp
 
 ## Available VM sizes
 
-  | CPU | RAM | Price | Size |
+  | CPU | GPU / RAM | Price | Size |
   | --- | --- | --- | --- |
-  | 2 CPU               | 4GB RAM           | £0.05 / hour | Standard_B2s
-  |  2 CPU              | 8GB RAM           | £0.15 / hour | Standard_D2s_v5
-  |  4 CPU              | 16GB RAM          | £0.30 / hour | Standard_D4s_v5
-  |  8 CPU              | 32GB RAM          | £0.65 / hour | Standard_D8s_v5
-  |  8 CPU              | 64GB RAM          | £0.75 / hour | Standard_E8as_v4
-  |  16 CPU             | 64GB RAM          | £1.25 / hour | Standard_D16s_v5
-  |  6 CPU - 112GB RAM  | 1 GPU - 16GB RAM  | £3.21 / hour | Standard_NC6s_v3
-  |  12 CPU - 224GB RAM | 2 GPU - 32GB RAM  | £6.42 / hour | Standard_NC12s_v3
+  |   2 CPU              | 4GB            | £0.05 / hour | Standard_B2s
+  |   2 CPU              | 8GB            | £0.15 / hour | Standard_D2s_v5
+  |   4 CPU              | 16GB           | £0.30 / hour | Standard_D4s_v5
+  |   8 CPU              | 32GB           | £0.65 / hour | Standard_D8s_v5
+  |   8 CPU              | 64GB           | £0.75 / hour | Standard_E8as_v4
+  |   16 CPU             | 64GB           | £1.25 / hour | Standard_D16s_v5
+  |   6 CPU - 112GB RAM  | 1 GPU - 16GB   | £3.21 / hour | Standard_NC6s_v3
+  |   12 CPU - 224GB RAM | 2 GPU - 32GB   | £6.42 / hour | Standard_NC12s_v3

--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -2,8 +2,20 @@
 
 Workspace Templates are located in this folder. These Templates are for the Composition Service to make instances of.
 
-| Template name | Description |
-| --- | --- |
-| tre-service-guacamole-linuxvm-ouh2    | This is a custom Linux image for OUH use   |
-| tre-service-guacamole-windowsvm-ouh2  | This is a custom Windows image for OUH use |
+| VM type | Template name | Description |
+| --- | --- | --- |
+| Linux   | tre-service-guacamole-linuxvm-ouh2    | This is a custom Linux image for OUH use   |
+| Windows | tre-service-guacamole-windowsvm-ouh2  | This is a custom Windows image for OUH use |
 
+## Available VM sizes
+
+  | CPU | RAM | Price | Size |
+  | --- | --- | --- | --- |
+  | 2 CPU               | 4GB RAM           | £0.05 / hour | Standard_B2s
+  |  2 CPU              | 8GB RAM           | £0.15 / hour | Standard_D2s_v5
+  |  4 CPU              | 16GB RAM          | £0.30 / hour | Standard_D4s_v5
+  |  8 CPU              | 32GB RAM          | £0.65 / hour | Standard_D8s_v5
+  |  8 CPU              | 64GB RAM          | £0.75 / hour | Standard_E8as_v4
+  |  16 CPU             | 64GB RAM          | £1.25 / hour | Standard_D16s_v5
+  |  6 CPU - 112GB RAM  | 1 GPU - 16GB RAM  | £3.21 / hour | Standard_NC6s_v3
+  |  12 CPU - 224GB RAM | 2 GPU - 32GB RAM  | £6.42 / hour | Standard_NC12s_v3


### PR DESCRIPTION
Test the merge when upgrading TRE from v15.2 to v16.0.

This branch will be used to merge into a dev TRE at 15.2 before merging feature/upgrade_16.0 into main.

**BREAKING CHANGES & MIGRATIONS**: To resolve the Airlock import issue described in (#3767), the new airlock import review template will need to be registered using make workspace_bundle BUNDLE=airlock-import-review. Any existing airlock import review workspaces will need to be upgraded.

Once you have upgraded the import review workspaces, delete the private endpoint, named pe-stg-import-inprogress-blob-* in the core resource group, and then run make deploy-core to reinstate the private endpoint and DNS records.

**ENHANCEMENTS**:

Security updates aligning to Dependabot, MS Defender for Cloud and Synk (#3796)
**BUG FIXES**:

- Fix issue where updates fail as read only is not configured consistently on schema fields (#3691)
- When getting available address spaces allow those allocated to deleted workspaces to be reassigned (#3691)
- Update Python packages, and fix breaking changes (#3764)
- Enabling support for more than 20 users/groups in Workspace API (#3759)
- Airlock Import Review workspace uses dedicated DNS zone to prevent conflict with core (#3767)