### PR TITLE
Merge Test for fix to Dockerfile and Windows git

### DIFF
--- a/.devcontainer/scripts/install-azure-tre-oss.sh
+++ b/.devcontainer/scripts/install-azure-tre-oss.sh
@@ -16,5 +16,5 @@ mkdir -p "$oss_home"
 tar -xzf "$archive" -C "$oss_home" --strip-components=1
 rm "$archive"
 
-# echo "${oss_repo}" > "$oss_home/repository.txt"
+echo "${oss_repo}" > "$oss_home/repository.txt"
 echo "${oss_version}" > "$oss_home/version.txt"


### PR DESCRIPTION
- The devcontainer began failing due to searching for a release version in our AzureTRE repo. This has now been added and the Dockerfile needed to be updated.

- Git in the Windows image is also out of date and requires an upgrade