### PR TITLE
Remove inner eye from workflow

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -373,8 +373,6 @@ jobs:
           - {BUNDLE_TYPE: "workspace_service",
              BUNDLE_DIR: "\\${AZURETRE_HOME}/templates/workspace_services/azureml"}
           - {BUNDLE_TYPE: "workspace_service",
-             BUNDLE_DIR: "\\${AZURETRE_HOME}/templates/workspace_services/innereye"}
-          - {BUNDLE_TYPE: "workspace_service",
              BUNDLE_DIR: "\\${AZURETRE_HOME}/templates/workspace_services/gitea"}
           - {BUNDLE_TYPE: "workspace_service",
              BUNDLE_DIR: "\\${AZURETRE_HOME}/templates/workspace_services/mlflow"}
@@ -534,8 +532,6 @@ jobs:
              BUNDLE_DIR: "\\${AZURETRE_HOME}/templates/workspace_services/guacamole"}
           - {BUNDLE_TYPE: "workspace_service",
              BUNDLE_DIR: "\\${AZURETRE_HOME}/templates/workspace_services/azureml"}
-          - {BUNDLE_TYPE: "workspace_service",
-             BUNDLE_DIR: "\\${AZURETRE_HOME}/templates/workspace_services/innereye"}
           - {BUNDLE_TYPE: "workspace_service",
              BUNDLE_DIR: "\\${AZURETRE_HOME}/templates/workspace_services/gitea"}
           - {BUNDLE_TYPE: "workspace_service",


### PR DESCRIPTION
Deploy TRE is currently failing on Publish InnerEYE template due to a porter version issue.

```
error building docker image: failed to solve: process "/bin/bash -o pipefail -c export PORTER_HOME=/home/\"$***USER***\"/.porter     && curl -L https://cdn.porter.sh/latest/install-linux.sh | bash     && \"$***PORTER_HOME***\"/porter mixin install docker" did not complete successfully: exit code: 1
unable to build CNAB invocation image: error building docker image: failed to solve: process "/bin/bash -o pipefail -c export PORTER_HOME=/home/\"$***USER***\"/.porter     && curl -L https://cdn.porter.sh/latest/install-linux.sh | bash     && \"$***PORTER_HOME***\"/porter mixin install docker" did not complete successfully: exit code: 1
unable to build CNAB invocation image: error building docker image: failed to solve: process "/bin/bash -o pipefail -c export PORTER_HOME=/home/\"$***USER***\"/.porter     && curl -L https://cdn.porter.sh/latest/install-linux.sh | bash     && \"$***PORTER_HOME***\"/porter mixin install docker" did not complete successfully: exit code: 1
make: *** [/home/vscode/AzureTRE/Makefile:189: bundle-build] Error 1
```

This is because the porter XML file does not contain the appropriate latest version of the mixin
`the feed at https://cdn.porter.sh/mixins/atom.xml does not contain an entry for exec @ v1.0.16`

Porter site that should contain v1.0.16 :  https://raw.githubusercontent.com/getporter/packages/main/mixins/atom.xml

Issue is being tracked in porter repo, but no response yet: issue: 2987

For now, as we do not use InnerEYE, I will remove the updated version form being published into our TRE.


This will allow us to run our pipeline and fix other errors