### PR TITLE
Test Lets Encrypt Fix

### DIFF
--- a/.github/workflows/lets_encrypt.yml
+++ b/.github/workflows/lets_encrypt.yml
@@ -2,10 +2,16 @@
 name: Renew Lets Encrypt Certificates
 
 on:  # yamllint disable-line rule:truthy
-  schedule:
-    # 3am each month https://crontab.guru/#0_3_1_*_*
-    - cron: "0 3 1 * *"
+  # schedule:
+  #   # 3am each month https://crontab.guru/#0_3_1_*_*
+  #   - cron: "0 3 1 * *"
   workflow_dispatch:
+    inputs:
+      environment:
+        description: The environment to run this workflow in
+        type: environment
+        default: CICD
+        required: true
 
 # This will prevent multiple runs of this entire workflow.
 # We should NOT cancel in progress runs as that can destabilize the environment.
@@ -20,59 +26,35 @@ jobs:
   renew_letsencrypt_certs:
     name: Renew Lets Encrypt Certificates
     runs-on: ubuntu-latest
-    environment: CICD
+    environment: ${{ github.event.inputs.environment || 'CICD' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.4.5
+          terraform_version: 1.2.9
           terraform_wrapper: false
 
-      # - name: Renew Certificates
-      #   shell: bash
-      #   env:
-      #     ARM_CLIENT_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientId }}
-      #     ARM_CLIENT_SECRET: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientSecret }}
-      #     ARM_SUBSCRIPTION_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).tenantId }}
-      #     ARM_TENANT_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).subscriptionId }}
-      #     TRE_ID: ${{ secrets.TRE_ID }}
-      #     TERRAFORM_STATE_CONTAINER_NAME:
-      #       ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME && secrets.TERRAFORM_STATE_CONTAINER_NAME || 'tfstate' }}
-      #     MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
-      #     MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
-      #   run: |
-      #     sudo apt-get install -y python3 python3-venv libaugeas0 \
-      #       && python3 -m venv /opt/certbot/ \
-      #       && /opt/certbot/bin/pip install --upgrade pip \
-      #       && /opt/certbot/bin/pip install certbot
-      #     make letsencrypt
-
       - name: Renew Certificates
-        uses: ./.github/actions/devcontainer_run_command
-        with:
-          COMMAND: "sudo apt-get install -y python3 python3-venv libaugeas0 \
+        shell: bash
+        env:
+          ARM_CLIENT_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientId }}
+          ARM_CLIENT_SECRET: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientSecret }}
+          ARM_SUBSCRIPTION_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).subscriptionId }}
+          ARM_TENANT_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).tenantId }}
+          AZURE_ENVIRONMENT: ${{ vars.AZURE_ENVIRONMENT }}
+          TRE_ID: ${{ secrets.TRE_ID }}
+          TF_VAR_terraform_state_container_name: ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME || 'tfstate' }}
+          TF_VAR_mgmt_resource_group_name: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
+          TF_VAR_mgmt_storage_account_name: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
+          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
+        run: |
+          sudo apt-get install -y python3 python3-venv libaugeas0 \
             && python3 -m venv /opt/certbot/ \
             && /opt/certbot/bin/pip install --upgrade pip \
             && /opt/certbot/bin/pip install certbot
-            make letsencrypt"
-          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
-          CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME}}
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          AZURE_ENVIRONMENT: ${{ vars.AZURE_ENVIRONMENT }}
-          ACR_NAME: ${{ secrets.ACR_NAME }}
-          API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
-          AAD_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
-          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
-          TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
-          TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-          TRE_ID: ${{ secrets.TRE_ID }}
-          LOCATION: ${{ vars.LOCATION }}
-          BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
-          TERRAFORM_STATE_CONTAINER_NAME: ${{ vars.TERRAFORM_STATE_CONTAINER_NAME }}
-          MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
-          MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
+          make letsencrypt


### PR DESCRIPTION
# Lets Encrypt workflow

## What is being addressed
Pull in change to Deployment Repo - https://github.com/microsoft/AzureTRE/pull/3979
Fix Lets Encrypt workflow

## How is this addressed

Pulled in description from above PR:

See details of issue, but in summary to fix the lets_encrypt.yml GitHub Action:

missing variable:
AZURE_ENVIRONMENT
values of the following variables were the wrong way around:
ARM_SUBSCRIPTION_ID
ARM_TENANT_ID
following variables needed passing in TF_VAR_varname form:
TERRAFORM_STATE_CONTAINER_NAME
MGMT_RESOURCE_GROUP_NAME
MGMT_STORAGE_ACCOUNT_NAME

In addition, the following minor changes were made:

- Add an environment selector to the workflow_dispatch, to allow users to run for different environments other than CICD.
- Commented out the schedule dispatch - I can see its perpetually failing on microsoft/AzureTRE, suggest its left up to forkers to determine whether to run on a schedule and for which environment? 
