### PR TITLE
Introduce new VM size

### DIFF
--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -19,6 +19,7 @@ Workspace Templates are located in this folder. These Templates are for the Comp
   |   16 CPU             | 64GB           | £1.25 / hour | Standard_D16s_v5
   |   6 CPU - 112GB RAM  | 1 GPU - 16GB   | £3.21 / hour | Standard_NC6s_v3
   |   12 CPU - 224GB RAM | 2 GPU - 32GB   | £6.42 / hour | Standard_NC12s_v3
+  |
 
 ## Current VM Image options
 

--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -11,15 +11,16 @@ Workspace Templates are located in this folder. These Templates are for the Comp
 
   | CPU | GPU / RAM | Price | Size |
   | --- | --- | --- | --- |
-  |   2 CPU              | 4GB            | £0.05 / hour | Standard_B2s
-  |   2 CPU              | 8GB            | £0.15 / hour | Standard_D2s_v5
-  |   4 CPU              | 16GB           | £0.30 / hour | Standard_D4s_v5
-  |   8 CPU              | 32GB           | £0.65 / hour | Standard_D8s_v5
-  |   8 CPU              | 64GB           | £0.75 / hour | Standard_E8as_v4
-  |   16 CPU             | 64GB           | £1.25 / hour | Standard_D16s_v5
-  |   6 CPU - 112GB RAM  | 1 GPU - 16GB   | £3.21 / hour | Standard_NC6s_v3
-  |   12 CPU - 224GB RAM | 2 GPU - 32GB   | £6.42 / hour | Standard_NC12s_v3
-  |
+  |   2 CPU              | 4GB                    | £0.05 / hour | Standard_B2s
+  |   2 CPU              | 8GB                    | £0.15 / hour | Standard_D2s_v5
+  |   4 CPU              | 16GB                   | £0.30 / hour | Standard_D4s_v5
+  |   8 CPU              | 32GB                   | £0.65 / hour | Standard_D8s_v5
+  |   8 CPU              | 64GB                   | £0.75 / hour | Standard_E8as_v4
+  |   16 CPU             | 64GB                   | £1.25 / hour | Standard_D16s_v5
+  |   6 CPU              | 55GB RAM - 1 A10 GPU   | £0.45 / hour | Standard_NV6ads_A10_v5
+  |   6 CPU - 112GB RAM  | 1 GPU - 16GB           | £3.21 / hour | Standard_NC6s_v3
+  |   12 CPU - 224GB RAM | 2 GPU - 32GB           | £6.42 / hour | Standard_NC12s_v3
+  
 
 ## Current VM Image options
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.16
+version: 1.0.2
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -15,8 +15,9 @@ custom:
     "8 CPU | 32GB RAM | £0.35 / hour": Standard_D8s_v5
     "8 CPU | 64GB RAM | £0.45 / hour": Standard_E8as_v4
     "16 CPU | 64GB RAM | £0.65 / hour": Standard_D16s_v5
-    "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £2.98 / hour": Standard_NC6s_v3
-    "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £5.96 / hour": Standard_NC12s_v3
+    "6 CPU - 55GB RAM | 1 A10 GPU - 4GB RAM | £0.45 / hour": Standard_NV6ads_A10_v5
+    "6 CPU - 112GB RAM | 1 V100 GPU - 16GB RAM | £3 / hour": Standard_NC6s_v3
+    "12 CPU - 224GB RAM | 2 V100 GPU - 32GB RAM | £6 / hour": Standard_NC12s_v3
   image_options:
     "Ubuntu 22.04 LTS":
       source_image_reference:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/template_schema.json
@@ -31,8 +31,9 @@
         "8 CPU | 32GB RAM | £0.35 / hour",
         "8 CPU | 64GB RAM | £0.45 / hour",
         "16 CPU | 64GB RAM | £0.65 / hour",
-        "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £2.98 / hour",
-        "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £5.96 / hour"
+        "6 CPU - 55GB RAM | 1 A10 GPU - 4GB RAM | £0.45 / hour",
+        "6 CPU - 112GB RAM | 1 V100 GPU - 16GB RAM | £3 / hour",
+        "12 CPU - 224GB RAM | 2 V100 GPU - 32GB RAM | £6 / hour"
       ],
       "updateable": true
     },

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm-ouh2
-version: 1.0.3
+version: 1.0.5
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -15,8 +15,9 @@ custom:
     "8 CPU | 32GB RAM | £0.65 / hour": Standard_D8s_v5
     "8 CPU | 64GB RAM | £0.75 / hour": Standard_E8as_v4
     "16 CPU | 64GB RAM | £1.25 / hour": Standard_D16s_v5
-    "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £3.21 / hour": Standard_NC6s_v3
-    "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £6.42 / hour": Standard_NC12s_v3
+    "6 CPU - 55GB RAM | 1 A10 GPU - 4GB RAM | £0.70 / hour": Standard_NV6ads_A10_v5
+    "6 CPU - 112GB RAM | 1 V100 GPU - 16GB RAM | £3.21 / hour": Standard_NC6s_v3
+    "12 CPU - 224GB RAM | 2 V100 GPU - 32GB RAM | £6.42 / hour": Standard_NC12s_v3
   image_options:
     "Windows 10":
       source_image_reference:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/template_schema.json
@@ -33,6 +33,7 @@
           "8 CPU | 32GB RAM | £0.65 / hour",
           "8 CPU | 64GB RAM | £0.75 / hour",
           "16 CPU | 64GB RAM | £1.25 / hour",
+          "6 CPU - 55GB RAM | 1 A10 GPU - 4GB RAM | £0.70 / hour",
           "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £3.21 / hour",
           "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £6.42 / hour"
         ],


### PR DESCRIPTION
## What is being addressed

New VM size added to list of options for all users. The [Standard_NV6ads_A10_v5](https://cloudprice.net/vm/Standard_NV6ads_A10_v5) will now be available for Windows and Linux.

File_mode=0777 also added to the vm-shared-storage so that users can save files directly to the file share.

Measures put in place to prevent screen locking, but not at a solution yet.

## How is this addressed
- add file_mode=0777
- Add to porter bundle template
- Below added
```## Prevent screen timeout and lock screen
echo "init_vm.sh: Disabling lock screen"

# Remove xfce4-screensaver (to disable screen saver)
sudo apt-get remove xfce4-screensaver -y

# Disable lock screen using gsettings
gsettings set org.gnome.desktop.screensaver lock-enabled false
gsettings set org.gnome.desktop.screensaver idle-activation-enabled false

# Disable lock screen via XFCE Power Manager settings
xfconf-query -c xfce4-power-manager -p /general/lockscreen-suspend-hibernate -s false
xfconf-query -c xfce4-power-manager -p /general/lockscreen -s false

```