### PR TITLE
Introduce new VM size

### DIFF
--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -11,16 +11,16 @@ Workspace Templates are located in this folder. These Templates are for the Comp
 
   | CPU | GPU / RAM | Price | Size |
   | --- | --- | --- | --- |
-  |   2 CPU              | 4GB            | £0.05 / hour | Standard_B2s
-  |   2 CPU              | 8GB            | £0.15 / hour | Standard_D2s_v5
-  |   4 CPU              | 16GB           | £0.30 / hour | Standard_D4s_v5
-  |   8 CPU              | 32GB           | £0.65 / hour | Standard_D8s_v5
-  |   8 CPU              | 64GB           | £0.75 / hour | Standard_E8as_v4
-  |   16 CPU             | 64GB           | £1.25 / hour | Standard_D16s_v5
-  |
-  |   6 CPU - 112GB RAM  | 1 GPU - 16GB   | £3.21 / hour | Standard_NC6s_v3
-  |   12 CPU - 224GB RAM | 2 GPU - 32GB   | £6.42 / hour | Standard_NC12s_v3
-  |
+  |   2 CPU              | 4GB                    | £0.05 / hour | Standard_B2s
+  |   2 CPU              | 8GB                    | £0.15 / hour | Standard_D2s_v5
+  |   4 CPU              | 16GB                   | £0.30 / hour | Standard_D4s_v5
+  |   8 CPU              | 32GB                   | £0.65 / hour | Standard_D8s_v5
+  |   8 CPU              | 64GB                   | £0.75 / hour | Standard_E8as_v4
+  |   16 CPU             | 64GB                   | £1.25 / hour | Standard_D16s_v5
+  |   6 CPU              | 55GB RAM - 1 A10 GPU   | £0.45 / hour | Standard_NV6ads_A10_v5
+  |   6 CPU - 112GB RAM  | 1 GPU - 16GB           | £3.21 / hour | Standard_NC6s_v3
+  |   12 CPU - 224GB RAM | 2 GPU - 32GB           | £6.42 / hour | Standard_NC12s_v3
+  
 
 ## Current VM Image options
 

--- a/templates/workspace_services/README.md
+++ b/templates/workspace_services/README.md
@@ -17,6 +17,7 @@ Workspace Templates are located in this folder. These Templates are for the Comp
   |   8 CPU              | 32GB           | £0.65 / hour | Standard_D8s_v5
   |   8 CPU              | 64GB           | £0.75 / hour | Standard_E8as_v4
   |   16 CPU             | 64GB           | £1.25 / hour | Standard_D16s_v5
+  |
   |   6 CPU - 112GB RAM  | 1 GPU - 16GB   | £3.21 / hour | Standard_NC6s_v3
   |   12 CPU - 224GB RAM | 2 GPU - 32GB   | £6.42 / hour | Standard_NC12s_v3
   |

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.7
+version: 1.0.2
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.5
+version: 1.0.6
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.4
+version: 1.0.5
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.2
+version: 1.0.3
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -15,9 +15,9 @@ custom:
     "8 CPU | 32GB RAM | £0.35 / hour": Standard_D8s_v5
     "8 CPU | 64GB RAM | £0.45 / hour": Standard_E8as_v4
     "16 CPU | 64GB RAM | £0.65 / hour": Standard_D16s_v5
-    "4 CPU - 28GB RAM | 1 GPU - 16GB RAM | £0.48 / hour": Standard_NC4as_T4_v3
-    "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £2.98 / hour": Standard_NC6s_v3
-    "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £5.96 / hour": Standard_NC12s_v3
+    "6 CPU - 55GB RAM | 1 A10 GPU - 4GB RAM | £0.45 / hour": Standard_NV6ads_A10_v5
+    "6 CPU - 112GB RAM | 1 V100 GPU - 16GB RAM | £3 / hour": Standard_NC6s_v3
+    "12 CPU - 224GB RAM | 2 V100 GPU - 32GB RAM | £6 / hour": Standard_NC12s_v3
   image_options:
     "Ubuntu 22.04 LTS":
       source_image_reference:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.3
+version: 1.0.4
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.2
+version: 1.0.3
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.16
+version: 1.0.2
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -15,6 +15,7 @@ custom:
     "8 CPU | 32GB RAM | £0.35 / hour": Standard_D8s_v5
     "8 CPU | 64GB RAM | £0.45 / hour": Standard_E8as_v4
     "16 CPU | 64GB RAM | £0.65 / hour": Standard_D16s_v5
+    "4 CPU - 28GB RAM | 1 GPU - 16GB RAM | £0.48 / hour": Standard_NC4as_T4_v3
     "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £2.98 / hour": Standard_NC6s_v3
     "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £5.96 / hour": Standard_NC12s_v3
   image_options:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.6
+version: 1.0.7
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm-ouh2
-version: 1.0.5
+version: 1.0.2
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/template_schema.json
@@ -31,9 +31,9 @@
         "8 CPU | 32GB RAM | £0.35 / hour",
         "8 CPU | 64GB RAM | £0.45 / hour",
         "16 CPU | 64GB RAM | £0.65 / hour",
-        "4 CPU - 28GB RAM | 1 GPU - 16GB RAM | £0.48 / hour",
-        "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £2.98 / hour",
-        "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £5.96 / hour"
+        "6 CPU - 55GB RAM | 1 A10 GPU - 4GB RAM | £0.45 / hour",
+        "6 CPU - 112GB RAM | 1 V100 GPU - 16GB RAM | £3 / hour",
+        "12 CPU - 224GB RAM | 2 V100 GPU - 32GB RAM | £6 / hour"
       ],
       "updateable": true
     },

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/template_schema.json
@@ -31,6 +31,7 @@
         "8 CPU | 32GB RAM | £0.35 / hour",
         "8 CPU | 64GB RAM | £0.45 / hour",
         "16 CPU | 64GB RAM | £0.65 / hour",
+        "4 CPU - 28GB RAM | 1 GPU - 16GB RAM | £0.48 / hour",
         "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £2.98 / hour",
         "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £5.96 / hour"
       ],

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -24,33 +24,15 @@ DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true dpkg-reconfigure
 sudo apt install -y xfce4 xfce4-goodies xorg dbus-x11 x11-xserver-utils
 echo /usr/sbin/gdm3 > /etc/X11/default-display-manager
 
-# Disable lock screen via GNOME lockdown settings
-gsettings set org.gnome.desktop.lockdown disable-lock-screen true
-gsettings set org.gnome.desktop.screensaver lock-enabled false
-gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
-gsettings set org.gnome.desktop.session idle-delay 0
-
 ## Install xrdp so Guacamole can connect via RDP
 echo "init_vm.sh: xrdp"
 sudo apt install -y xrdp xorgxrdp xfce4-session
 sudo adduser xrdp ssl-cert
 sudo -u "${VM_USER}" -i bash -c 'echo xfce4-session > ~/.xsession'
-sudo -u "${VM_USER}" -i bash -c 'echo xset s off >> ~/.xsession'  # Disable screensaver timeout
-sudo -u "${VM_USER}" -i bash -c 'echo xset -dpms >> ~/.xsession' # Disable DPMS screen power management
-
-# # Disable the lock screen in xfce4-power-manager
-# echo "Disabling lock screen in xfce4-power-manager"
-# sudo -u "${VM_USER}" bash -c 'echo "<property name=\"lock-screen-suspend-hibernate\" type=\"bool\" value=\"false\"/>" >> ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml'
-
-# # Disable lock screen in xfce4-screensaver
-# echo "Disabling lock screen in xfce4-screensaver"
-# sudo -u "${VM_USER}" bash -c 'echo "[Xfce4Screensaver]" > ~/.config/xfce4/xfce4-screensaver/settings.conf'
-# sudo -u "${VM_USER}" bash -c 'echo "lock-enabled=false" >> ~/.config/xfce4/xfce4-screensaver/settings.conf'
 
 # Make sure xrdp service starts up with the system
 sudo systemctl enable xrdp
 sudo service xrdp restart
-
 
 # Azure Storage Explorer
 sudo apt-get remove -y dotnet-host-7.0

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -19,6 +19,7 @@ sudo apt-get update || true
 
 ## Desktop
 echo "init_vm.sh: Desktop"
+sudo apt-get install gdm3
 sudo systemctl start gdm3 || true
 DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true dpkg-reconfigure gdm3 || true
 sudo apt install -y xfce4 xfce4-goodies xorg dbus-x11 x11-xserver-utils
@@ -161,9 +162,24 @@ sudo systemctl restart docker
 # Jupiter Notebook Config
 sudo sed -i -e 's/Terminal=true/Terminal=false/g' /usr/share/applications/jupyter-notebook.desktop
 
-# Prevent screen timeout
-echo "init_vm.sh: Preventing Timeout"
+## Prevent screen timeout and lock screen
+echo "init_vm.sh: Disabling lock screen"
+
+# Remove xfce4-screensaver (to disable screen saver)
 sudo apt-get remove xfce4-screensaver -y
+
+# Disable lock screen using gsettings
+gsettings set org.gnome.desktop.screensaver lock-enabled false
+gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
+
+# Disable lock screen via XFCE Power Manager settings
+xfconf-query -c xfce4-power-manager -p /general/lockscreen-suspend-hibernate -s false
+xfconf-query -c xfce4-power-manager -p /general/lockscreen -s false
+
+# Also, if using gdm3, ensure it's not locking the session
+sudo sh -c 'echo "[org/gnome/desktop/screensaver]\nlock-enabled=false" >> /etc/gdm3/greeter.dconf-defaults'
+
+
 
 ## Cleanup
 echo "init_vm.sh: Cleanup"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -26,6 +26,9 @@ echo /usr/sbin/gdm3 > /etc/X11/default-display-manager
 
 # Disable lock screen via GNOME lockdown settings
 gsettings set org.gnome.desktop.lockdown disable-lock-screen true
+gsettings set org.gnome.desktop.screensaver lock-enabled false
+gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
+gsettings set org.gnome.desktop.session idle-delay 0
 
 ## Install xrdp so Guacamole can connect via RDP
 echo "init_vm.sh: xrdp"
@@ -37,16 +40,27 @@ sudo -u "${VM_USER}" -i bash -c 'echo xset -dpms >> ~/.xsession' # Disable DPMS 
 
 # Disable the lock screen in xfce4-power-manager
 echo "Disabling lock screen in xfce4-power-manager"
-sudo -u "${VM_USER}" bash -c 'echo "<property name=\"lock-screen-suspend-hibernate\" type=\"bool\" value=\"false\"/>" >> ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml'
+sudo -u "${VM_USER}" bash -c 'mkdir -p ~/.config/xfce4/xfconf/xfce-perchannel-xml/'
+sudo -u "${VM_USER}" bash -c 'cat > ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xfce4-power-manager" version="1.0">
+  <property name="lock-screen-suspend-hibernate" type="bool" value="false"/>
+  <property name="blank-on-inactive" type="int" value="0"/>
+</channel>
+EOF'
 
 # Disable lock screen in xfce4-screensaver
 echo "Disabling lock screen in xfce4-screensaver"
-sudo -u "${VM_USER}" bash -c 'echo "[Xfce4Screensaver]" > ~/.config/xfce4/xfce4-screensaver/settings.conf'
-sudo -u "${VM_USER}" bash -c 'echo "lock-enabled=false" >> ~/.config/xfce4/xfce4-screensaver/settings.conf'
+sudo -u "${VM_USER}" bash -c 'mkdir -p ~/.config/xfce4/xfce4-screensaver/'
+sudo -u "${VM_USER}" bash -c 'cat > ~/.config/xfce4/xfce4-screensaver/settings.conf <<EOF
+[Xfce4Screensaver]
+lock-enabled=false
+EOF'
 
 # Make sure xrdp service starts up with the system
 sudo systemctl enable xrdp
 sudo service xrdp restart
+
 
 # Azure Storage Explorer
 sudo apt-get remove -y dotnet-host-7.0

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -40,22 +40,12 @@ sudo -u "${VM_USER}" -i bash -c 'echo xset -dpms >> ~/.xsession' # Disable DPMS 
 
 # Disable the lock screen in xfce4-power-manager
 echo "Disabling lock screen in xfce4-power-manager"
-sudo -u "${VM_USER}" bash -c 'mkdir -p ~/.config/xfce4/xfconf/xfce-perchannel-xml/'
-sudo -u "${VM_USER}" bash -c 'cat > ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<channel name="xfce4-power-manager" version="1.0">
-  <property name="lock-screen-suspend-hibernate" type="bool" value="false"/>
-  <property name="blank-on-inactive" type="int" value="0"/>
-</channel>
-EOF'
+sudo -u "${VM_USER}" bash -c 'echo "<property name=\"lock-screen-suspend-hibernate\" type=\"bool\" value=\"false\"/>" >> ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml'
 
 # Disable lock screen in xfce4-screensaver
 echo "Disabling lock screen in xfce4-screensaver"
-sudo -u "${VM_USER}" bash -c 'mkdir -p ~/.config/xfce4/xfce4-screensaver/'
-sudo -u "${VM_USER}" bash -c 'cat > ~/.config/xfce4/xfce4-screensaver/settings.conf <<EOF
-[Xfce4Screensaver]
-lock-enabled=false
-EOF'
+sudo -u "${VM_USER}" bash -c 'echo "[Xfce4Screensaver]" > ~/.config/xfce4/xfce4-screensaver/settings.conf'
+sudo -u "${VM_USER}" bash -c 'echo "lock-enabled=false" >> ~/.config/xfce4/xfce4-screensaver/settings.conf'
 
 # Make sure xrdp service starts up with the system
 sudo systemctl enable xrdp

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -38,14 +38,14 @@ sudo -u "${VM_USER}" -i bash -c 'echo xfce4-session > ~/.xsession'
 sudo -u "${VM_USER}" -i bash -c 'echo xset s off >> ~/.xsession'  # Disable screensaver timeout
 sudo -u "${VM_USER}" -i bash -c 'echo xset -dpms >> ~/.xsession' # Disable DPMS screen power management
 
-# Disable the lock screen in xfce4-power-manager
-echo "Disabling lock screen in xfce4-power-manager"
-sudo -u "${VM_USER}" bash -c 'echo "<property name=\"lock-screen-suspend-hibernate\" type=\"bool\" value=\"false\"/>" >> ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml'
+# # Disable the lock screen in xfce4-power-manager
+# echo "Disabling lock screen in xfce4-power-manager"
+# sudo -u "${VM_USER}" bash -c 'echo "<property name=\"lock-screen-suspend-hibernate\" type=\"bool\" value=\"false\"/>" >> ~/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml'
 
-# Disable lock screen in xfce4-screensaver
-echo "Disabling lock screen in xfce4-screensaver"
-sudo -u "${VM_USER}" bash -c 'echo "[Xfce4Screensaver]" > ~/.config/xfce4/xfce4-screensaver/settings.conf'
-sudo -u "${VM_USER}" bash -c 'echo "lock-enabled=false" >> ~/.config/xfce4/xfce4-screensaver/settings.conf'
+# # Disable lock screen in xfce4-screensaver
+# echo "Disabling lock screen in xfce4-screensaver"
+# sudo -u "${VM_USER}" bash -c 'echo "[Xfce4Screensaver]" > ~/.config/xfce4/xfce4-screensaver/settings.conf'
+# sudo -u "${VM_USER}" bash -c 'echo "lock-enabled=false" >> ~/.config/xfce4/xfce4-screensaver/settings.conf'
 
 # Make sure xrdp service starts up with the system
 sudo systemctl enable xrdp

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -134,6 +134,54 @@ sudo echo -e "local({\n    r <- getOption(\"repos\")\n    r[\"Nexus\"] <- \"""${
 # Fix for blank screen on DSVM (/sh -> /bash due to conflict with profile.d scripts)
 sudo sed -i 's|!/bin/sh|!/bin/bash|g' /etc/xrdp/startwm.sh
 
+# Create the Desktop directory if it doesn't exist
+sudo -u "$VM_USER" mkdir -p /home/"$VM_USER"/Desktop
+
+# Add a README file to the Desktop
+README_PATH="/home/$VM_USER/Desktop/README.txt"
+sudo -u "$VM_USER" bash -c "cat > $README_PATH" << 'EOF'
+Welcome to your Linux VM!
+
+This VM is pre-configured with the following tools:
+- XFCE Desktop Environment
+- Azure Storage Explorer
+- RStudio Desktop
+- Docker
+- Anaconda
+
+To get started:
+1. Open any application using the Applications Menu.
+2. Use RStudio or Jupyter Notebook for data analysis.
+3. Access your shared file storage at /fileshares/vm-shared-storage (if configured).
+4. See the package mirror options by accessing http://nexus-tvstre.uksouth.cloudapp.azure.com
+
+Recommendations:
+1. R packages may fail to install initially. If you see an error, edit Rprofile to use the local package mirror:
+
+sudo nano /usr/lib/R/etc/Rprofile.site
+
+Replace the local(...) lines at the bottom with:
+local({
+    r <- getOption("repos")
+    r["Nexus"] <- "http://nexus-tvstre.uksouth.cloudapp.azure.com/repository/r-proxy/"
+    options(repos = r)
+})
+
+2. Disable XFCE Lock Screen otherwise you may get locked out:
+
+Open Applications > Settings > Screensaver; click on Lock Screen tab, disable the Lock Screen.
+
+
+For further assistance, contact your administrator.
+
+Enjoy!
+EOF
+
+# Set appropriate permissions for the README file
+sudo chmod 644 "$README_PATH"
+sudo chown "$VM_USER:$VM_USER" "$README_PATH"
+
+
 ### Anaconda Config
 if [ "${CONDA_CONFIG}" == "true" ]; then
   export PATH="/opt/anaconda/condabin":$PATH

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -19,7 +19,6 @@ sudo apt-get update || true
 
 ## Desktop
 echo "init_vm.sh: Desktop"
-sudo apt-get install gdm3
 sudo systemctl start gdm3 || true
 DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true dpkg-reconfigure gdm3 || true
 sudo apt install -y xfce4 xfce4-goodies xorg dbus-x11 x11-xserver-utils
@@ -175,10 +174,6 @@ gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
 # Disable lock screen via XFCE Power Manager settings
 xfconf-query -c xfce4-power-manager -p /general/lockscreen-suspend-hibernate -s false
 xfconf-query -c xfce4-power-manager -p /general/lockscreen -s false
-
-# Also, if using gdm3, ensure it's not locking the session
-sudo sh -c 'echo "[org/gnome/desktop/screensaver]\nlock-enabled=false" >> /etc/gdm3/greeter.dconf-defaults'
-
 
 
 ## Cleanup

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -134,49 +134,45 @@ sudo echo -e "local({\n    r <- getOption(\"repos\")\n    r[\"Nexus\"] <- \"""${
 # Fix for blank screen on DSVM (/sh -> /bash due to conflict with profile.d scripts)
 sudo sed -i 's|!/bin/sh|!/bin/bash|g' /etc/xrdp/startwm.sh
 
-sudo bash -c "cat > /home" << 'EOF'
-testing a file
-EOF
-
 # Add a README file to the Desktop
-README_PATH="/home/$VM_USER/Desktop/README.txt"
-sudo -u "$VM_USER" bash -c "cat > $README_PATH" << 'EOF'
-Welcome to your Linux VM!
+# README_PATH="/home/$VM_USER/Desktop/README.txt"
+# sudo -u "$VM_USER" bash -c "cat > $README_PATH" << 'EOF'
+# Welcome to your Linux VM!
 
-This VM is pre-configured with the following tools:
-- XFCE Desktop Environment
-- Azure Storage Explorer
-- RStudio Desktop
-- Docker
-- Anaconda
+# This VM is pre-configured with the following tools:
+# - XFCE Desktop Environment
+# - Azure Storage Explorer
+# - RStudio Desktop
+# - Docker
+# - Anaconda
 
-To get started:
-1. Open any application using the Applications Menu.
-2. Use RStudio or Jupyter Notebook for data analysis.
-3. Access your shared file storage at /fileshares/vm-shared-storage (if configured).
-4. See the package mirror options by accessing http://nexus-tvstre.uksouth.cloudapp.azure.com
+# To get started:
+# 1. Open any application using the Applications Menu.
+# 2. Use RStudio or Jupyter Notebook for data analysis.
+# 3. Access your shared file storage at /fileshares/vm-shared-storage (if configured).
+# 4. See the package mirror options by accessing http://nexus-tvstre.uksouth.cloudapp.azure.com
 
-Recommendations:
-1. R packages may fail to install initially. If you see an error, edit Rprofile to use the local package mirror:
+# Recommendations:
+# 1. R packages may fail to install initially. If you see an error, edit Rprofile to use the local package mirror:
 
-sudo nano /usr/lib/R/etc/Rprofile.site
+# sudo nano /usr/lib/R/etc/Rprofile.site
 
-Replace the local(...) lines at the bottom with:
-local({
-    r <- getOption("repos")
-    r["Nexus"] <- "http://nexus-tvstre.uksouth.cloudapp.azure.com/repository/r-proxy/"
-    options(repos = r)
-})
+# Replace the local(...) lines at the bottom with:
+# local({
+#     r <- getOption("repos")
+#     r["Nexus"] <- "http://nexus-tvstre.uksouth.cloudapp.azure.com/repository/r-proxy/"
+#     options(repos = r)
+# })
 
-2. Disable XFCE Lock Screen otherwise you may get locked out:
+# 2. Disable XFCE Lock Screen otherwise you may get locked out:
 
-Open Applications > Settings > Screensaver; click on Lock Screen tab, disable the Lock Screen.
+# Open Applications > Settings > Screensaver; click on Lock Screen tab, disable the Lock Screen.
 
 
-For further assistance, contact your administrator.
+# For further assistance, contact your administrator.
 
-Enjoy!
-EOF
+# Enjoy!
+# EOF
 
 # Set appropriate permissions for the README file
 sudo chmod 644 "$README_PATH"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -134,8 +134,9 @@ sudo echo -e "local({\n    r <- getOption(\"repos\")\n    r[\"Nexus\"] <- \"""${
 # Fix for blank screen on DSVM (/sh -> /bash due to conflict with profile.d scripts)
 sudo sed -i 's|!/bin/sh|!/bin/bash|g' /etc/xrdp/startwm.sh
 
-# Create the Desktop directory if it doesn't exist
-sudo -u "$VM_USER" mkdir -p /home/"$VM_USER"/Desktop
+sudo bash -c "cat > /home" << 'EOF'
+testing a file
+EOF
 
 # Add a README file to the Desktop
 README_PATH="/home/$VM_USER/Desktop/README.txt"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm-ouh2/terraform/vm_config.sh
@@ -29,6 +29,8 @@ echo "init_vm.sh: xrdp"
 sudo apt install -y xrdp xorgxrdp xfce4-session
 sudo adduser xrdp ssl-cert
 sudo -u "${VM_USER}" -i bash -c 'echo xfce4-session > ~/.xsession'
+sudo -u "${VM_USER}" -i bash -c 'echo xset s off >> ~/.xsession'
+sudo -u "${VM_USER}" -i bash -c 'echo xset -dpms >> ~/.xsession'
 
 # Make sure xrdp service starts up with the system
 sudo systemctl enable xrdp

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm-ouh2
-version: 1.0.4
+version: 1.0.5
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -15,9 +15,9 @@ custom:
     "8 CPU | 32GB RAM | £0.65 / hour": Standard_D8s_v5
     "8 CPU | 64GB RAM | £0.75 / hour": Standard_E8as_v4
     "16 CPU | 64GB RAM | £1.25 / hour": Standard_D16s_v5
-    "4 CPU - 28GB RAM | 1 GPU - 16GB RAM | £0.62 / hour": Standard_NC4as_T4_v3
-    "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £3.21 / hour": Standard_NC6s_v3
-    "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £6.42 / hour": Standard_NC12s_v3
+    "6 CPU - 55GB RAM | 1 A10 GPU - 4GB RAM | £0.70 / hour": Standard_NV6ads_A10_v5
+    "6 CPU - 112GB RAM | 1 V100 GPU - 16GB RAM | £3.21 / hour": Standard_NC6s_v3
+    "12 CPU - 224GB RAM | 2 V100 GPU - 32GB RAM | £6.42 / hour": Standard_NC12s_v3
   image_options:
     "Windows 10":
       source_image_reference:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm-ouh2
-version: 1.0.3
+version: 1.0.4
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -15,6 +15,7 @@ custom:
     "8 CPU | 32GB RAM | £0.65 / hour": Standard_D8s_v5
     "8 CPU | 64GB RAM | £0.75 / hour": Standard_E8as_v4
     "16 CPU | 64GB RAM | £1.25 / hour": Standard_D16s_v5
+    "4 CPU - 28GB RAM | 1 GPU - 16GB RAM | £0.62 / hour": Standard_NC4as_T4_v3
     "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £3.21 / hour": Standard_NC6s_v3
     "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £6.42 / hour": Standard_NC12s_v3
   image_options:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/template_schema.json
@@ -33,6 +33,7 @@
           "8 CPU | 32GB RAM | £0.65 / hour",
           "8 CPU | 64GB RAM | £0.75 / hour",
           "16 CPU | 64GB RAM | £1.25 / hour",
+          "4 CPU - 28GB RAM | 1 GPU - 16GB RAM | £0.62 / hour",
           "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £3.21 / hour",
           "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £6.42 / hour"
         ],

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm-ouh2/template_schema.json
@@ -33,7 +33,7 @@
           "8 CPU | 32GB RAM | £0.65 / hour",
           "8 CPU | 64GB RAM | £0.75 / hour",
           "16 CPU | 64GB RAM | £1.25 / hour",
-          "4 CPU - 28GB RAM | 1 GPU - 16GB RAM | £0.62 / hour",
+          "6 CPU - 55GB RAM | 1 A10 GPU - 4GB RAM | £0.70 / hour",
           "6 CPU - 112GB RAM | 1 GPU - 16GB RAM | £3.21 / hour",
           "12 CPU - 224GB RAM | 2 GPU - 32GB RAM | £6.42 / hour"
         ],


### PR DESCRIPTION
## What is being addressed

New VM size added to list of options for all users. The [Standard_NV6ads_A10_v5](https://cloudprice.net/vm/Standard_NV6ads_A10_v5) will now be available for Windows and Linux.

File_mode=0777 also added to the vm-shared-storage so that users can save files directly to the file share.

Measures put in place to prevent screen locking, but not at a solution yet.

## How is this addressed
- add file_mode=0777
- Add to porter bundle template
- Below added
```## Prevent screen timeout and lock screen
echo "init_vm.sh: Disabling lock screen"

# Remove xfce4-screensaver (to disable screen saver)
sudo apt-get remove xfce4-screensaver -y

# Disable lock screen using gsettings
gsettings set org.gnome.desktop.screensaver lock-enabled false
gsettings set org.gnome.desktop.screensaver idle-activation-enabled false

# Disable lock screen via XFCE Power Manager settings
xfconf-query -c xfce4-power-manager -p /general/lockscreen-suspend-hibernate -s false
xfconf-query -c xfce4-power-manager -p /general/lockscreen -s false

```