### PR TITLE
MERGE TEST / TVS TRE - Migration to Separate Prod Branch 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
       "DOCKER_GROUP_ID": "${localEnv:DOCKER_GROUP_ID}",
       "INTERACTIVE": "true",
       "UPSTREAM_REPO": "OxBRCInformatics/AzureTRE",
-      "UPSTREAM_REPO_VERSION": "v0.21.1",
+      "UPSTREAM_REPO_VERSION": "tvstre-prod-main-v0.21.2",
       "GITHUB_TOKEN": ""
     }
   },


### PR DESCRIPTION
TRE run id: 1f8f40f0

Migrate to a new tag, based on the new branch tvstre-prod-main.

The Deployment repo must now point to this new branch within the AzureTRE repo so that all upstream changes can be synced and merged in turn during TRE upgrades.

See https://github.com/tvs-sde/TVSTRE_admin_docs/blob/main/upgrade_tre/TVSTRE_Git_Management_Strategy.md for details